### PR TITLE
Fix incorrect item getting edited

### DIFF
--- a/src/pages/TodoListPage.vue
+++ b/src/pages/TodoListPage.vue
@@ -102,11 +102,13 @@ const markTodoItem = async (id: number, done: boolean) => {
 };
 
 const onEditTodoItem = async (id: number) => {
+  // NOTE: Assuming that this is never null
+  const todoItem = todo.value.items?.find((item) => item.id === id);
   $q.dialog({
     title: 'Edit item',
     message: 'Enter new text for the item',
     prompt: {
-      model: todo.value.items[id].content,
+      model: todoItem.content,
       type: 'text',
       isValid: (content) => !!content,
       label: 'Todo Item Text',


### PR DESCRIPTION
When attempting to edit a todo item, it was possible for the wrong item
to be selected to set the initial value. Sometimes, it would attempt to
select an initial value that didn't exist, causing the edit dialog to
simply never pop up. This was because the ID of the todo item was being
used as the index to select from an array of todo items.

Fixes #25
